### PR TITLE
Static content serving

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -208,10 +208,10 @@ quarantine:
   allowLocalAdmins: true
 
 # static content settings (all disabled by default)
-staticContent:
-  - server: t2bot.io # server for which that static content is valid
-    mxcPrefix: example # prefix for the mxc
-    directory: /path/to/folder # folder where the content is
-    filePrefix: images_ # prefix for the files to add
-    fileSuffix: .png # suffix for the files to add
-    contentType: "" # content type. Empty means autodetect
+#staticContent:
+#  - server: t2bot.io # server for which that static content is valid
+#    mxcPrefix: example # prefix for the mxc
+#    directory: /path/to/folder # folder where the content is
+#    filePrefix: images_ # prefix for the files to add
+#    fileSuffix: .png # suffix for the files to add
+#    contentType: "" # content type. Empty means autodetect

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -206,3 +206,12 @@ quarantine:
   # only. Global administrators can quarantine any media (local or remote) regardless of this
   # flag.
   allowLocalAdmins: true
+
+# static content settings (all disabled by default)
+staticContent:
+  - server: t2bot.io # server for which that static content is valid
+    mxcPrefix: example # prefix for the mxc
+    directory: /path/to/folder # folder where the content is
+    filePrefix: images_ # prefix for the files to add
+    fileSuffix: .png # suffix for the files to add
+    contentType: "" # content type. Empty means autodetect

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -215,3 +215,10 @@ quarantine:
 #    filePrefix: images_ # prefix for the files to add
 #    fileSuffix: .png # suffix for the files to add
 #    contentType: "" # content type. Empty means autodetect
+#    tryFiles: # if this array is defined then the fileSuffix/contentType is ignored
+#      - suffix: .png
+#        contentType: image/png
+#      - suffix: .jpg
+#        contentType: image/jpeg
+#      - suffix: .gif
+#        contentType: image/gif

--- a/src/github.com/turt2live/matrix-media-repo/config/config.go
+++ b/src/github.com/turt2live/matrix-media-repo/config/config.go
@@ -100,13 +100,19 @@ type QuarantineConfig struct {
 	AllowLocalAdmins  bool   `yaml:"allowLocalAdmins"`
 }
 
-type StaticContentConfig struct {
-	Server      string `yaml:"server"`
-	MxcPrefix   string `yaml:"mxcPrefix"`
-	Directory   string `yaml:"directory"`
-	FilePrefix  string `yaml:"filePrefix"`
-	FileSuffix  string `yaml:"fileSuffix"`
+type StaticContentTryFiles struct {
+	Suffix      string `yaml:"suffix"`
 	ContentType string `yaml:"contentType"`
+}
+
+type StaticContentConfig struct {
+	Server      string                   `yaml:"server"`
+	MxcPrefix   string                   `yaml:"mxcPrefix"`
+	Directory   string                   `yaml:"directory"`
+	FilePrefix  string                   `yaml:"filePrefix"`
+	FileSuffix  string                   `yaml:"fileSuffix"`
+	ContentType string                   `yaml:"contentType"`
+	TryFiles    []*StaticContentTryFiles `yaml:"tryFiles"`
 }
 
 type MediaRepoConfig struct {

--- a/src/github.com/turt2live/matrix-media-repo/config/config.go
+++ b/src/github.com/turt2live/matrix-media-repo/config/config.go
@@ -100,18 +100,28 @@ type QuarantineConfig struct {
 	AllowLocalAdmins  bool   `yaml:"allowLocalAdmins"`
 }
 
+type StaticContentConfig struct {
+	Server      string `yaml:"server"`
+	MxcPrefix   string `yaml:"mxcPrefix"`
+	Directory   string `yaml:"directory"`
+	FilePrefix  string `yaml:"filePrefix"`
+	FileSuffix  string `yaml:"fileSuffix"`
+	ContentType string `yaml:"contentType"`
+}
+
 type MediaRepoConfig struct {
-	General     *GeneralConfig      `yaml:"repo"`
-	Homeservers []*HomeserverConfig `yaml:"homeservers,flow"`
-	Admins      []string            `yaml:"admins,flow"`
-	Database    *DatabaseConfig     `yaml:"database"`
-	Uploads     *UploadsConfig      `yaml:"uploads"`
-	Downloads   *DownloadsConfig    `yaml:"downloads"`
-	Thumbnails  *ThumbnailsConfig   `yaml:"thumbnails"`
-	UrlPreviews *UrlPreviewsConfig  `yaml:"urlPreviews"`
-	RateLimit   *RateLimitConfig    `yaml:"rateLimit"`
-	Identicons  *IdenticonsConfig   `yaml:"identicons"`
-	Quarantine  *QuarantineConfig   `yaml:"quarantine"`
+	General        *GeneralConfig         `yaml:"repo"`
+	Homeservers    []*HomeserverConfig    `yaml:"homeservers,flow"`
+	Admins         []string               `yaml:"admins,flow"`
+	Database       *DatabaseConfig        `yaml:"database"`
+	Uploads        *UploadsConfig         `yaml:"uploads"`
+	Downloads      *DownloadsConfig       `yaml:"downloads"`
+	Thumbnails     *ThumbnailsConfig      `yaml:"thumbnails"`
+	UrlPreviews    *UrlPreviewsConfig     `yaml:"urlPreviews"`
+	RateLimit      *RateLimitConfig       `yaml:"rateLimit"`
+	Identicons     *IdenticonsConfig      `yaml:"identicons"`
+	Quarantine     *QuarantineConfig      `yaml:"quarantine"`
+	StaticContents []*StaticContentConfig `yaml:"staticContent,flow"`
 }
 
 var instance *MediaRepoConfig
@@ -261,5 +271,6 @@ func NewDefaultConfig() *MediaRepoConfig {
 			ReplaceThumbnails: true,
 			ThumbnailPath:     "",
 		},
+		StaticContents: []*StaticContentConfig{},
 	}
 }

--- a/src/github.com/turt2live/matrix-media-repo/media_cache/media_cache.go
+++ b/src/github.com/turt2live/matrix-media-repo/media_cache/media_cache.go
@@ -77,7 +77,7 @@ func (c *mediaCache) GetRawMedia(server string, mediaId string) (*types.Media, e
 	c.log.Info("Searching for media")
 	media, err := mediaSvc.GetMediaDirect(server, mediaId)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if err == sql.ErrNoRows || err == errs.ErrMediaNotFound {
 			if util.IsServerOurs(server) {
 				c.log.Warn("Media not found")
 				return nil, errs.ErrMediaNotFound

--- a/src/github.com/turt2live/matrix-media-repo/services/media_service/media_service.go
+++ b/src/github.com/turt2live/matrix-media-repo/services/media_service/media_service.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/ryanuber/go-glob"
 	"github.com/sirupsen/logrus"
@@ -29,6 +30,58 @@ func New(ctx context.Context, log *logrus.Entry) (*mediaService) {
 }
 
 func (s *mediaService) GetMediaDirect(server string, mediaId string) (*types.Media, error) {
+	// first check if we have static content to serve
+	for _, v := range config.Get().StaticContents {
+		// first check if it is for our server
+		// and check if the MXC url starts with our prefix
+		if v.Server != server || !strings.HasPrefix(mediaId, v.MxcPrefix) {
+			continue
+		}
+		
+		// okay, this is something for us to handle!
+		sanitizedMediaId := mediaId[len(v.MxcPrefix):]
+		// make sure that the media ID is actually valid (contains no /)
+		if strings.ContainsAny(sanitizedMediaId, "/") {
+			return nil, errs.ErrMediaNotFound
+		}
+		filename := v.FilePrefix + sanitizedMediaId + v.FileSuffix
+		path := v.Directory + "/" + filename
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, errs.ErrMediaNotFound
+		}
+		fi, err := file.Stat()
+		if err != nil {
+			return nil, errs.ErrMediaNotFound
+		}
+		defer file.Close()
+		
+		hash, err := storage.GetFileHash(path)
+		if err != nil {
+			return nil, errs.ErrMediaNotFound
+		}
+		
+		contentType := v.ContentType
+		if contentType == "" {
+			contentType, err = storage.GetFileContentType(path)
+			if err != nil {
+				return nil, errs.ErrMediaNotFound
+			}
+		}
+		
+		return &types.Media{
+			Origin: server,
+			MediaId: mediaId,
+			UploadName: filename,
+			ContentType: contentType,
+			UserId: "",
+			Sha256Hash: hash,
+			SizeBytes: fi.Size(),
+			Location: path,
+			CreationTs: fi.ModTime().Unix(),
+			Quarantined: false,
+		}, nil
+	}
 	return s.store.Get(server, mediaId)
 }
 

--- a/src/github.com/turt2live/matrix-media-repo/storage/file_store.go
+++ b/src/github.com/turt2live/matrix-media-repo/storage/file_store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"path"
 
@@ -101,4 +102,21 @@ func GetFileHash(filePath string) (string, error) {
 	}
 
 	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func GetFileContentType(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	buffer := make([]byte, 512)
+
+	_, err = f.Read(buffer)
+	defer f.Close()
+	if err != nil {
+		return "", err
+	}
+
+	return http.DetectContentType(buffer), nil
 }


### PR DESCRIPTION
This PR enables the possibility to serve some static content via MXC URLs. For example, you could dump a bunch of images into a directory and then call them with `mxc://myhomeserver/images-blah` where that resolves to `blah.png` in a certain folder on the server store.

If such a feature is unwanted in matrix-media-repo just go ahead and close this PR