### PR TITLE
Improve upload mime filtering

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -50,6 +50,15 @@ uploads:
   allowedTypes:
    - "*/*"
 
+  # If not all file types are allowed, then you can make an exlusion for some users. So 
+  # that users can upload file types that not allowed to others.
+  #exclusions:
+  #  "@admin1:matrix.org":
+  #     - "application/pdf"
+  #     - "application/vnd.ms-excel"
+  #  "@admin2:matrix.org": [*/*]
+
+
 # Settings related to downloading files from the media repository
 downloads:
   # The maximum number of bytes to download from other servers

--- a/src/github.com/turt2live/matrix-media-repo/common/config/config.go
+++ b/src/github.com/turt2live/matrix-media-repo/common/config/config.go
@@ -32,10 +32,11 @@ type DatabaseConfig struct {
 }
 
 type UploadsConfig struct {
-	StoragePaths         []string `yaml:"storagePaths,flow"`
-	MaxSizeBytes         int64    `yaml:"maxBytes"`
-	AllowedTypes         []string `yaml:"allowedTypes,flow"`
-	ReportedMaxSizeBytes int64    `yaml:"reportedMaxBytes"`
+	StoragePaths         []string            `yaml:"storagePaths,flow"`
+	MaxSizeBytes         int64               `yaml:"maxBytes"`
+	AllowedTypes         []string            `yaml:"allowedTypes,flow"`
+	AllowedExcl          map[string][]string `yaml:"exclusions,flow"`
+	ReportedMaxSizeBytes int64               `yaml:"reportedMaxBytes"`
 }
 
 type DownloadsConfig struct {

--- a/src/github.com/turt2live/matrix-media-repo/controllers/upload_controller/upload_controller.go
+++ b/src/github.com/turt2live/matrix-media-repo/controllers/upload_controller/upload_controller.go
@@ -68,13 +68,17 @@ func StoreDirect(contents io.Reader, contentType string, filename string, userId
 		return nil, err
 	}
 
+	allowed := false
 	for _, allowedType := range config.Get().Uploads.AllowedTypes {
-		if !glob.Glob(allowedType, fileMime) {
+		if glob.Glob(allowedType, fileMime) {
+			allowed = true
+		}
+	}
+	if !allowed {
 			log.Warn("Content type " + fileMime +" (reported as " + contentType+") is not allowed to be uploaded")
 
 			os.Remove(fileLocation) // delete temp file
 			return nil, common.ErrMediaNotAllowed
-		}
 	}
 
 	hash, err := storage.GetFileHash(fileLocation)


### PR DESCRIPTION
Fix for https://github.com/turt2live/matrix-media-repo/issues/109
and
Upload exclusions implementation: If not all file types are allowed, then you can make an exlusion for some users. So that users can upload file types that not allowed to others.