### PR TITLE
Fix tempfile handling for SVG thumbnailing

### DIFF
--- a/src/github.com/turt2live/matrix-media-repo/controllers/thumbnail_controller/thumbnail_resource_handler.go
+++ b/src/github.com/turt2live/matrix-media-repo/controllers/thumbnail_controller/thumbnail_resource_handler.go
@@ -350,7 +350,7 @@ func svgToImage(media *types.Media, ctx context.Context, log *logrus.Entry) (ima
 		return nil, err
 	}
 
-	f, err := os.Open(tempFile1)
+	f, err := os.OpenFile(tempFile1, os.O_RDWR|os.O_CREATE, 0640)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The earlier usage of regular Open (without explicit create-if-not-exists semantic) can fail as the tempfile is ensured removed just a few lines above, changing this to OpenFile with O_CREATE solves that issue.