### PR TITLE
Update sample config to clarify that - needs quotes around it

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -4,7 +4,9 @@ repo:
   port: 8000
 
   # Where to store the logs, relative to where the repo is started from. Logs will be automatically
-  # rotated every day and held for 14 days. To disable the repo logging to files, set this to "-".
+  # rotated every day and held for 14 days. To disable the repo logging to files, set this to
+  # "-" (including quotation marks).
+  #
   # Note: to change the log directory you'll have to restart the repository. This setting cannot be
   # live reloaded.
   logDirectory: logs


### PR DESCRIPTION
I set my `logDirectory` config option to `-`, instead of `"-"`, because I am a silly user.

This produces the helpful startup error message:

```
block sequence entries are not allowed in this context
```

I thought the comment could use some clarification.