### PR TITLE
Properly thumbnail gifs with different frame disposal methods

### DIFF
--- a/controllers/thumbnail_controller/thumbnail_resource_handler.go
+++ b/controllers/thumbnail_controller/thumbnail_resource_handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"image/color"
 	"image/draw"
 	"image/gif"
 	"io"
@@ -238,15 +239,18 @@ func GenerateThumbnail(media *types.Media, width int, height int, method string,
 		}
 
 		// Prepare a blank frame to use as swap space
-		frameImg := image.NewRGBA(g.Image[0].Bounds())
+		frameImg := image.NewRGBA(image.Rectangle{image.Point{0, 0}, image.Point{g.Config.Width, g.Config.Height}})
+		// make sure the image is transparent at the start
+		draw.Draw(frameImg, frameImg.Bounds(), image.Transparent, image.ZP, draw.Src)
 
 		for i := range g.Image {
 			img := g.Image[i]
 			disposal := g.Disposal[i]
 
-			// Clear the transparency of the previous frame
-			if disposal == 0 {
-				draw.Draw(frameImg, frameImg.Bounds(), image.Transparent, image.ZP, draw.Src)
+			var previousImg draw.Image
+			if disposal == 3 {
+				previousImg = image.NewRGBA(g.Image[0].Bounds())
+				draw.Draw(previousImg, frameImg.Bounds(), frameImg, image.ZP, draw.Over)
 			}
 
 			// Copy the frame to a new image and use that
@@ -264,6 +268,24 @@ func GenerateThumbnail(media *types.Media, width int, height int, method string,
 			targetImg := image.NewPaletted(frameThumb.Bounds(), img.Palette)
 			draw.FloydSteinberg.Draw(targetImg, frameThumb.Bounds(), frameThumb, image.ZP)
 			g.Image[i] = targetImg
+
+			// determine how to dispose the frame
+			// see https://www.w3.org/Graphics/GIF/spec-gif89a.txt
+			if disposal == 0 {
+				// Clear the transparency of the previous frame
+				draw.Draw(frameImg, frameImg.Bounds(), image.Transparent, image.ZP, draw.Src)
+			} else if disposal == 1 {
+				// do nothing
+			} else if disposal == 2 && g.Config.ColorModel != nil {
+				// restore background color
+				background := g.Config.ColorModel.(color.Palette)[g.BackgroundIndex]
+				if background != nil {
+					draw.Draw(frameImg, frameImg.Bounds(), image.NewUniform(background), image.ZP, draw.Src)
+				}
+			} else if disposal == 3 && previousImg != nil {
+				// restore previous frame
+				draw.Draw(frameImg, frameImg.Bounds(), previousImg, image.ZP, draw.Over)
+			}
 		}
 
 		// Set the image size to the first frame's size

--- a/controllers/thumbnail_controller/thumbnail_resource_handler.go
+++ b/controllers/thumbnail_controller/thumbnail_resource_handler.go
@@ -258,12 +258,6 @@ func GenerateThumbnail(media *types.Media, width int, height int, method string,
 				draw.Draw(frameImg, frameImg.Bounds(), image.Transparent, image.ZP, draw.Src)
 			}
 
-			var previousFrameImg draw.Image
-			if disposal == 3 {
-				previousFrameImg = image.NewRGBA(frameImg.Bounds())
-				draw.Draw(previousFrameImg, frameImg.Bounds(), frameImg, image.ZP, draw.Over)
-			}
-
 			// Copy the frame to a new image and use that
 			draw.Draw(frameImg, frameImg.Bounds(), img, image.ZP, draw.Over)
 

--- a/controllers/thumbnail_controller/thumbnail_resource_handler.go
+++ b/controllers/thumbnail_controller/thumbnail_resource_handler.go
@@ -243,13 +243,14 @@ func GenerateThumbnail(media *types.Media, width int, height int, method string,
 		for i := range g.Image {
 			img := g.Image[i]
 			var disposal byte
+			// use disposal method 0 by default
 			if g.Disposal == nil {
 				disposal = 0
 			} else {
 				disposal = g.Disposal[i]
 			}
 
-			// if disposal type is 1 (preserve previous frame) we can get artifacts from re-scaling
+			// if disposal type is 1 (preserve previous frame) we can get artifacts from re-scaling.
 			// as such, we re-render those frames to disposal type 0 (start with a transparent frame)
 			// see https://www.w3.org/Graphics/GIF/spec-gif89a.txt
 			if disposal == 1 {

--- a/controllers/thumbnail_controller/thumbnail_resource_handler.go
+++ b/controllers/thumbnail_controller/thumbnail_resource_handler.go
@@ -242,9 +242,12 @@ func GenerateThumbnail(media *types.Media, width int, height int, method string,
 
 		for i := range g.Image {
 			img := g.Image[i]
+			disposal := g.Disposal[i]
 
 			// Clear the transparency of the previous frame
-			draw.Draw(frameImg, frameImg.Bounds(), image.Transparent, image.ZP, draw.Src)
+			if disposal == 0 {
+				draw.Draw(frameImg, frameImg.Bounds(), image.Transparent, image.ZP, draw.Src)
+			}
 
 			// Copy the frame to a new image and use that
 			draw.Draw(frameImg, frameImg.Bounds(), img, image.ZP, draw.Over)

--- a/controllers/thumbnail_controller/thumbnail_resource_handler.go
+++ b/controllers/thumbnail_controller/thumbnail_resource_handler.go
@@ -245,7 +245,13 @@ func GenerateThumbnail(media *types.Media, width int, height int, method string,
 
 		for i := range g.Image {
 			img := g.Image[i]
-			disposal := g.Disposal[i]
+			var disposal byte
+			if g.Disposal == nil {
+				// go 1.14
+				disposal = 0
+			} else {
+				disposal = g.Disposal[i]
+			}
 
 			var previousImg draw.Image
 			if disposal == 3 {


### PR DESCRIPTION
Support all disposal methods of gifs

Example of wrong thumbnailing:

original: 
![celestia](https://user-images.githubusercontent.com/2433620/83662352-a72c6180-a5c7-11ea-8e5c-07890ba1d8af.gif)

wrong thumbnail: 
![thumbnail](https://user-images.githubusercontent.com/2433620/83662387-b6131400-a5c7-11ea-936c-4c70da66d903.gif)

fixed thumbnail: 
![thumbnail](https://user-images.githubusercontent.com/2433620/83662437-c0351280-a5c7-11ea-8e70-ac7c8bdc03e6.gif)
