### PR TITLE
add webp support

### DIFF
--- a/controllers/thumbnail_controller/thumbnail_resource_handler.go
+++ b/controllers/thumbnail_controller/thumbnail_resource_handler.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/chai2010/webp"
 	"github.com/disintegration/imaging"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -154,7 +155,11 @@ func GenerateThumbnail(media *types.Media, width int, height int, method string,
 			return nil, err2
 		}
 		defer cleanup.DumpAndCloseStream(mediaStream)
-		src, err = imaging.Decode(mediaStream)
+		if media.ContentType == "image/webp" {
+			src, err = webp.Decode(mediaStream)
+		} else {
+			src, err = imaging.Decode(mediaStream)
+		}
 	}
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/bep/debounce v1.2.0
 	github.com/buckket/go-blurhash v1.0.3
 	github.com/cenk/backoff v2.2.1+incompatible // indirect
+	github.com/chai2010/webp v1.1.0
 	github.com/cupcake/sigil v0.0.0-20131127230922-6bf9722f2ae8
 	github.com/didip/tollbooth v4.0.2+incompatible
 	github.com/disintegration/imaging v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chai2010/webp v1.1.0 h1:4Ei0/BRroMF9FaXDG2e4OxwFcuW2vcXd+A6tyqTJUQQ=
+github.com/chai2010/webp v1.1.0/go.mod h1:LP12PG5IFmLGHUU26tBiCBKnghxx3toZFwDjOYvd3Ow=
 github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
 github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
There is currently no webp encoder / decoder, so the media repo fails with

```
ERRO[2020-06-17 11:03:27.786 Z] Unexpected error locating media: image: unknown format  allowRemote=true contentLength=0 contentType="" host=localhost mediaId=d2c101e6adc14854e568068699125791d3217ec2 method=GET queryString="" remoteAddr=127.0.0.1 requestId=REQ-1 requestedAnimated=true requestedHeight=32 requestedMethod=scale requestedWidth=32 resource=/_matrix/media/r0/thumbnail/localhost/d2c101e6adc14854e568068699125791d3217ec2 server=localhost usingForwardedHost=false
```

This PR fixes webp thumbnailing. The actual thumbnails themself are png again, though, if wanted the webp-ness of the thumbnails can be preserved.

This PR does not support animated webp images