### PR TITLE
Fix empty Content-Type header on retrieved remote media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fixed the Synapse import script to not skip duplicated media. Thanks @jaywink!
 * Fixed requests to IPv6 hosts. Thanks @MatMaul!
 * Removed excessive calls to the database during upload.
+* Fixed empty Content-Type header on retrieved remote media.
 
 ## [1.1.2] - April 21st, 2020
 

--- a/controllers/download_controller/download_resource_handler.go
+++ b/controllers/download_controller/download_resource_handler.go
@@ -147,7 +147,7 @@ func downloadResourceWorkFn(request *resource_handler.WorkRequest) interface{} {
 		}
 
 		ctx.Log.Info("Remote media persisted under datastore ", media.DatastoreId, " at ", media.Location)
-		return &workerDownloadResponse{media: media}
+		return &workerDownloadResponse{media: media, contentType: media.ContentType}
 	}
 
 	if info.blockForMedia {


### PR DESCRIPTION
As found in #244: the first request for remote media resulted in (apparent) binary blobs. This was caused by the `Content-Type` header not being set.

This PR addresses the problem by... setting it!