### PR TITLE
Fix IPv6 host/port joining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fixed federation with some homeserver setups (delegation with ports). Thanks @MatMaul!
 * Fixed the Synapse import script to not skip duplicated media. Thanks @jaywink!
 * Fixed requests to IPv6 hosts. Thanks @MatMaul!
+* Fixed listening on IPv6 addresses.
 * Removed excessive calls to the database during upload.
 
 ## [1.1.2] - April 21st, 2020

--- a/api/webserver/webserver.go
+++ b/api/webserver/webserver.go
@@ -3,6 +3,7 @@ package webserver
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -192,7 +193,7 @@ func Init() *sync.WaitGroup {
 		handler = tollbooth.LimitHandler(limiter, rtr)
 	}
 
-	address := config.Get().General.BindAddress + ":" + strconv.Itoa(config.Get().General.Port)
+	address := net.JoinHostPort(config.Get().General.BindAddress, strconv.Itoa(config.Get().General.Port))
 	httpMux := http.NewServeMux()
 	httpMux.Handle("/", handler)
 

--- a/controllers/preview_controller/previewers/http.go
+++ b/controllers/preview_controller/previewers/http.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -59,19 +58,15 @@ func doHttpGet(urlPayload *preview_types.UrlPayload, languageHeader string, ctx 
 		}
 
 		safeIpStr := safeIp.String()
-		// IPv6 needs smthg of the form [::] because we explicitly happen the port
-		if safeIp.To4() == nil {
-			safeIpStr = "[" + safeIpStr + "]"
-		}
 
-		expectedAddr := fmt.Sprintf("%s:%s", urlPayload.ParsedUrl.Host, safePort)
-		altAddr := fmt.Sprintf("%s:%s", urlPayload.ParsedUrl.Host, altPort)
+		expectedAddr := net.JoinHostPort(urlPayload.ParsedUrl.Host, safePort)
+		altAddr := net.JoinHostPort(urlPayload.ParsedUrl.Host, altPort)
 
 		returnAddr := ""
 		if addr == expectedAddr {
-			returnAddr = fmt.Sprintf("%s:%s", safeIpStr, safePort)
+			returnAddr = net.JoinHostPort(safeIpStr, safePort)
 		} else if addr == altAddr && altPort != "" {
-			returnAddr = fmt.Sprintf("%s:%s", safeIpStr, altPort)
+			returnAddr = net.JoinHostPort(safeIpStr, altPort)
 		}
 
 		if returnAddr != "" {

--- a/metrics/webserver.go
+++ b/metrics/webserver.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -30,7 +31,7 @@ func Init() {
 	rtr.HandleFunc("/metrics", internalHandler)
 	rtr.HandleFunc("/_media/metrics", internalHandler)
 
-	address := config.Get().Metrics.BindAddress + ":" + strconv.Itoa(config.Get().Metrics.Port)
+	address := net.JoinHostPort(config.Get().Metrics.BindAddress, strconv.Itoa(config.Get().Metrics.Port))
 	srv = &http.Server{Addr: address, Handler: rtr}
 	go func() {
 		logrus.WithField("address", address).Info("Started metrics listener. Listening at http://" + address)


### PR DESCRIPTION
In various places in the code base, the address and port are joined using a `:`. This causes issues with IPv6-addresses (see #247).
Address this by using `net.JoinHostPort` everywhere.

*Most* cases I modified are fairly minor and shouldn't happen often. The only noticeable change is that the listen address now works properly, so that's what I put in the changelog.