### PR TITLE
correctly respect exif orientation of thumbnailed images

### DIFF
--- a/util/util_exif/exif.go
+++ b/util/util_exif/exif.go
@@ -58,7 +58,7 @@ func GetExifOrientation(media *types.Media) (*ExifOrientation, error) {
 		degrees = 180
 	} else if orientation == 5 || orientation == 6 {
 		degrees = 270
-	} else if orientation == 7 || degrees == 8 {
+	} else if orientation == 7 || orientation == 8 {
 		degrees = 90
 	}
 


### PR DESCRIPTION
Currently when thumbnailing jpegs etc. the orientation in the exif information of the images is ignores. This PR fixes that, using https://github.com/disintegration/imageorient