### PR TITLE
Bring back defaultAnimated option

### DIFF
--- a/api/r0/thumbnail.go
+++ b/api/r0/thumbnail.go
@@ -45,7 +45,7 @@ func ThumbnailMedia(r *http.Request, rctx rcontext.RequestContext, user api.User
 
 	width := 0
 	height := 0
-	animated := false
+	animated := rctx.Config.Thumbnails.AllowAnimated && rctx.Config.Thumbnails.DefaultAnimated
 
 	if widthStr != "" {
 		parsedWidth, err := strconv.Atoi(widthStr)


### PR DESCRIPTION
https://github.com/turt2live/matrix-media-repo/commit/2239ff5f88ae4858a207d2b14a6953f87d39ca7b accidentally removed it