### PR TITLE
Thumbnail jpgs as jpgs to not increase thumbnail size

### DIFF
--- a/thumbnailing/i/jpg.go
+++ b/thumbnailing/i/jpg.go
@@ -51,13 +51,13 @@ func (d jpgGenerator) GenerateThumbnail(b []byte, contentType string, width int,
 	}
 
 	imgData := &bytes.Buffer{}
-	err = imaging.Encode(imgData, thumb, imaging.PNG)
+	err = imaging.Encode(imgData, thumb, imaging.JPEG)
 	if err != nil {
 		return nil, errors.New("jpg: error encoding thumbnail: " + err.Error())
 	}
 	return &m.Thumbnail{
 		Animated:    false,
-		ContentType: "image/png",
+		ContentType: "image/jpeg",
 		Reader:      ioutil.NopCloser(imgData),
 	}, nil
 }


### PR DESCRIPTION
Alternative suggestion to #288 to fix the underlying issue of thumbnails being larger than source images