### PR TITLE
fix: Some gifs not thumbnailing correctly

### DIFF
--- a/thumbnailing/i/gif.go
+++ b/thumbnailing/i/gif.go
@@ -49,17 +49,6 @@ func (d gifGenerator) GenerateThumbnail(b []byte, contentType string, width int,
 			disposal = g.Disposal[i]
 		}
 
-		// if disposal type is 0 or 1 (preserve previous frame) we can get artifacts from re-scaling.
-		// as such, we re-render those frames to disposal type 1 (do not dispose)
-		// Importantly, we do not clear the previous frame buffer canvas
-		// see https://www.w3.org/Graphics/GIF/spec-gif89a.txt
-		// This also applies to frame disposal type 0, https://legacy.imagemagick.org/Usage/anim_basics/#none
-		if disposal == 1 || disposal == 0 {
-			g.Disposal[i] = 1
-		} else {
-			draw.Draw(frameImg, frameImg.Bounds(), image.Transparent, image.Point{X: 0, Y: 0}, draw.Src)
-		}
-
 		// Copy the frame to a new image and use that
 		draw.Draw(frameImg, frameImg.Bounds(), img, image.Point{X: 0, Y: 0}, draw.Over)
 
@@ -94,6 +83,17 @@ func (d gifGenerator) GenerateThumbnail(b []byte, contentType string, width int,
 				ContentType: "image/png",
 				Reader: ioutil.NopCloser(buf),
 			}, nil
+		}
+
+		// if disposal type is 0 or 1 (preserve previous frame) we can get artifacts from re-scaling.
+		// as such, we re-render those frames to disposal type 1 (do not dispose)
+		// Importantly, we do not clear the previous frame buffer canvas
+		// see https://www.w3.org/Graphics/GIF/spec-gif89a.txt
+		// This also applies to frame disposal type 0, https://legacy.imagemagick.org/Usage/anim_basics/#none
+		if disposal == 1 || disposal == 0 {
+			g.Disposal[i] = 1
+		} else {
+			draw.Draw(frameImg, frameImg.Bounds(), image.Transparent, image.Point{X: 0, Y: 0}, draw.Src)
 		}
 
 		g.Image[i] = targetImg

--- a/thumbnailing/i/gif.go
+++ b/thumbnailing/i/gif.go
@@ -49,11 +49,13 @@ func (d gifGenerator) GenerateThumbnail(b []byte, contentType string, width int,
 			disposal = g.Disposal[i]
 		}
 
-		// if disposal type is 1 (preserve previous frame) we can get artifacts from re-scaling.
-		// as such, we re-render those frames to disposal type 0 (start with a transparent frame)
+		// if disposal type is 0 or 1 (preserve previous frame) we can get artifacts from re-scaling.
+		// as such, we re-render those frames to disposal type 1 (do not dispose)
+		// Importantly, we do not clear the previous frame buffer canvas
 		// see https://www.w3.org/Graphics/GIF/spec-gif89a.txt
-		if disposal == 1 {
-			g.Disposal[i] = 0
+		// This also applies to frame disposal type 0, https://legacy.imagemagick.org/Usage/anim_basics/#none
+		if disposal == 1 || disposal == 0 {
+			g.Disposal[i] = 1
 		} else {
 			draw.Draw(frameImg, frameImg.Bounds(), image.Transparent, image.Point{X: 0, Y: 0}, draw.Src)
 		}


### PR DESCRIPTION
It appears that soru incorrectly assumed that, for gifs, a frame disposal method of 0 (undefined) is "clear to transparent background".

As it turns out, that frame disposal method is the same as frame disposal method 1 "do not dispose"

As most gifs with frame disposal 0 in the wild are full-frame for every frame anyways, which means it doesn't matter which of the methods you pick

This is apparently incorrect for some, and this PR fixes that.

This has been tested with a variety of gifs having disposal 0 and disposal 1, really hope this finally fixes all the issues....