### PR TITLE
Set default Content-Disposition of plain text media to 'inline'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+* `Content-Disposition` of plain text files now defaults to `inline`.
+
 ## [1.2.4] - March 5th, 2021
 
 ### Fixed

--- a/api/webserver/route_handler.go
+++ b/api/webserver/route_handler.go
@@ -192,7 +192,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if result.ContentType == "" {
 				disposition = "attachment"
 			} else {
-				if util.HasAnyPrefix(result.ContentType, []string{"image/", "audio/", "video/"}) {
+				if util.HasAnyPrefix(result.ContentType, []string{"image/", "audio/", "video/", "text/plain"}) {
 					disposition = "inline"
 				} else {
 					disposition = "attachment"


### PR DESCRIPTION
Set the default `Content-Disposition` of files with the `text/plain` content types to `inline`. This ensures that web browsers show these messages, instead of downloading them. 

This is mainly useful for the IRC bridge, as it sends long Matrix messages as links to `text/plain` files on IRC. These are now a single click away for IRC users.