### PR TITLE
Add support for setting max upload size per user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 In a future version (likely the next), the in-memory cache support will be removed. Instead, please use the Redis
 caching that is now supported properly by this release, or disable caching if not applicable for your deployment.
 
+### Added
+
+* Added support for setting maximum individual upload size per user
+
 ### Changed
 
 * Support the Redis config at the root level of the config, promoting it to a proper feature.

--- a/api/r0/upload.go
+++ b/api/r0/upload.go
@@ -35,6 +35,11 @@ func UploadMedia(r *http.Request, rctx rcontext.RequestContext, user api.UserInf
 		contentType = "application/octet-stream" // binary
 	}
 
+	if upload_controller.IsRequestTooLargeForUser(r.ContentLength, r.Header.Get("Content-Length"), rctx, user.UserId) {
+		io.Copy(ioutil.Discard, r.Body) // Ditch the entire request
+		return api.RequestTooLarge()
+	}
+
 	if upload_controller.IsRequestTooLarge(r.ContentLength, r.Header.Get("Content-Length"), rctx) {
 		io.Copy(ioutil.Discard, r.Body) // Ditch the entire request
 		return api.RequestTooLarge()

--- a/common/config/conf_min_shared.go
+++ b/common/config/conf_min_shared.go
@@ -23,6 +23,10 @@ func NewDefaultMinimumRepoConfig() MinimumRepoConfig {
 			MaxSizeBytes:         104857600, // 100mb
 			MinSizeBytes:         100,
 			ReportedMaxSizeBytes: 0,
+			MaxBytesPerUser: MaxBytesPerUserConfig{
+				Enabled:      false,
+				UserMaxBytes: []MaxBytesUserConfig{},
+			},
 			Quota: QuotasConfig{
 				Enabled:    false,
 				UserQuotas: []QuotaUserConfig{},

--- a/common/config/models_domain.go
+++ b/common/config/models_domain.go
@@ -16,11 +16,22 @@ type QuotasConfig struct {
 	UserQuotas []QuotaUserConfig `yaml:"users,flow"`
 }
 
+type MaxBytesUserConfig struct {
+	Glob	 string `yaml:"glob"`
+	MaxBytes int64  `yaml:"maxBytes"`
+}
+
+type MaxBytesPerUserConfig struct {
+	Enabled      bool                 `yaml:"enabled"`
+	UserMaxBytes []MaxBytesUserConfig `yaml:"users,flow"`
+}
+
 type UploadsConfig struct {
-	MaxSizeBytes         int64        `yaml:"maxBytes"`
-	MinSizeBytes         int64        `yaml:"minBytes"`
-	ReportedMaxSizeBytes int64        `yaml:"reportedMaxBytes"`
-	Quota                QuotasConfig `yaml:"quotas"`
+	MaxSizeBytes         int64                 `yaml:"maxBytes"`
+	MinSizeBytes         int64                 `yaml:"minBytes"`
+	ReportedMaxSizeBytes int64                 `yaml:"reportedMaxBytes"`
+  MaxBytesPerUser      MaxBytesPerUserConfig `yaml:"maxBytesPerUser"`
+	Quota                QuotasConfig          `yaml:"quotas"`
 }
 
 type DatastoreConfig struct {

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -219,6 +219,16 @@ uploads:
   # Set this to -1 to indicate that there is no limit. Zero will force the use of maxBytes.
   #reportedMaxBytes: 104857600
 
+  # Per user maximum file size limits. Global maximum will also apply unless disabled.
+  # Rules are evaluated using an identical method to upload quotas.
+  maxBytesPerUser:
+    # Whether or not the per user maximum is enabled.
+    enabled: false
+    # Per user upload maximum rules.
+    users:
+      - glob: "@*:*"
+        maxBytes: 0
+
   # Options for limiting how much content a user can upload. Quotas are applied to content
   # associated with a user regardless of de-duplication. Quotas which affect remote servers
   # or users will not take effect. When a user exceeds their quota they will be unable to


### PR DESCRIPTION
This works similarly to user quotas. Depending on the configuration, specific users or groups of users can have a lower or higher file upload limit than the default.