### PR TITLE
Let health check endpoint accept HEAD method

### DIFF
--- a/api/webserver/webserver.go
+++ b/api/webserver/webserver.go
@@ -170,7 +170,7 @@ func Init() *sync.WaitGroup {
 	}
 
 	// Health check endpoints
-	rtr.Handle("/healthz", healthzHandler).Methods("OPTIONS", "GET")
+	rtr.Handle("/healthz", healthzHandler).Methods("OPTIONS", "GET", "HEAD")
 
 	rtr.NotFoundHandler = handler{api.NotFoundHandler, "not_found", counter, true}
 	rtr.MethodNotAllowedHandler = handler{api.MethodNotAllowedHandler, "method_not_allowed", counter, true}


### PR DESCRIPTION
Fixes #331

```
$ curl --head http://127.0.0.1:8000/healthz
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization
Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
Access-Control-Allow-Origin: *
Content-Security-Policy: sandbox; default-src 'none'; script-src 'none'; plugin-types application/pdf; style-src 'unsafe-inline'; media-src 'self'; object-src 'self';
Content-Type: application/json
Server: matrix-media-repo
X-Rate-Limit-Duration: 1
X-Rate-Limit-Limit: 1.00
X-Rate-Limit-Request-Forwarded-For: 
X-Rate-Limit-Request-Remote-Addr: 127.0.0.1:50814
X-Robots-Tag: noindex, nofollow, noarchive, noimageindex
Date: Thu, 05 Aug 2021 01:33:48 GMT
Content-Length: 4
```