### PR TITLE
Grafana: Sort tooltip decreasing on Thumbnail Generation and Resource Handling

### DIFF
--- a/docs/grafana.json
+++ b/docs/grafana.json
@@ -704,7 +704,7 @@
       "title": "Thumbnail Generation",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -801,7 +801,7 @@
       "title": "Resource Handling",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",


### PR DESCRIPTION
The last 2 panels on the Grafana dashboard show a lot of homeservers on the tooltip, and it usually goes off the screen. This PR sorts the tooltip on those two panels by decreasing, so the ones that are happening at a higher rate wherever you're hovering show up at the top of the tooltip box.

Before:

![image](https://user-images.githubusercontent.com/17971474/131238134-8e0558e3-5b2a-437d-8308-44970856aea4.png)

After:

![image](https://user-images.githubusercontent.com/17971474/131238095-5e767e97-cd53-4d5c-8b87-48cbc5c25405.png)

(these images were taken while hovering over the same point in time on the graph)