### PR TITLE
Handle file not existing when trying to delete it

### DIFF
--- a/storage/datastore/ds_file/file_store.go
+++ b/storage/datastore/ds_file/file_store.go
@@ -120,5 +120,10 @@ func PersistFileAtLocation(targetFile string, file io.ReadCloser, ctx rcontext.R
 }
 
 func DeletePersistedFile(basePath string, location string) error {
-	return os.Remove(path.Join(basePath, location))
+	err := os.Remove(path.Join(basePath, location))
+	if err != nil && os.IsNotExist(err) {
+		// It didn't exist, so pretend it was successful
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
When trying to clean up database after a faulty config deleted the
existing files, I called /_matrix/media/r0/admin/purge/old but that was
failing due to the file not existing.

Code jsut swallows the error as deleting a non existing file shouldn't
be fatal

Logs-ish:

Deleting thumbnail with hash: e8ba5faa6bae71647a3a8e7e6328bf3d93343e96666eda14e5487b5e60760d80" before_ts=1632086268000 contentLength=2 contentType=application/json include_local=true isRepoAdmin=true method=POST queryString="before_ts=1632086268000&include_local=true&keep_profiles=false" resource=/_matrix/media/r0/admin/purge/old usingForwardedHost=true
Error purging media: remove /var/matrix/media/c3/43/82a1828f3222468497ac8ccc0f490b252c6a: no such file or directory"
Replying with result: *api.ErrorResponse &{Code:M_UNKNOWN Message:error purging media InternalCode:M_UNKNOWN}" contentLength=2 contentType=application/json method=POST queryString="before_ts=1632086268000&include_local=true&keep_profiles=false"  resource=/_matrix/media/r0/admin/purge/old usingForwardedHost=true