### PR TITLE
Add `urlPreviews.userAgent` config.

### DIFF
--- a/common/config/conf_domain.go
+++ b/common/config/conf_domain.go
@@ -46,6 +46,7 @@ func NewDefaultDomainConfig() DomainRepoConfig {
 				"0.0.0.0/0", // "Everything"
 			},
 			DefaultLanguage: "en-US,en",
+			UserAgent:       "matrix-media-repo",
 			OEmbed:          false,
 		},
 		Thumbnails: ThumbnailsConfig{

--- a/common/config/conf_main.go
+++ b/common/config/conf_main.go
@@ -82,6 +82,7 @@ func NewDefaultMainConfig() MainRepoConfig {
 					"0.0.0.0/0", // "Everything"
 				},
 				DefaultLanguage: "en-US,en",
+				UserAgent:       "matrix-media-repo",
 				OEmbed:          false,
 			},
 			NumWorkers: 10,

--- a/common/config/models_domain.go
+++ b/common/config/models_domain.go
@@ -64,6 +64,7 @@ type UrlPreviewsConfig struct {
 	AllowedNetworks    []string `yaml:"allowedNetworks,flow"`
 	UnsafeCertificates bool     `yaml:"previewUnsafeCertificates"`
 	DefaultLanguage    string   `yaml:"defaultLanguage"`
+	UserAgent		   string   `yaml:"userAgent"`
 	OEmbed             bool     `yaml:"oEmbed"`
 }
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -351,6 +351,9 @@ urlPreviews:
   # Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
   defaultLanguage: "en-US,en"
 
+  # Set the User-Agent header to supply when generating URL previews
+  userAgent: "matrix-media-repo"
+
   # When true, oEmbed previews will be enabled. Typically these kinds of previews are used for
   # sites that do not support OpenGraph or page scraping, such as Twitter. For information on
   # specifying providers for oEmbed, including your own, see the following documentation:

--- a/controllers/preview_controller/previewers/http.go
+++ b/controllers/preview_controller/previewers/http.go
@@ -118,7 +118,7 @@ func doHttpGet(urlPayload *preview_types.UrlPayload, languageHeader string, ctx 
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", "matrix-media-repo")
+	req.Header.Set("User-Agent", ctx.Config.UrlPreviews.UserAgent)
 	req.Header.Set("Accept-Language", languageHeader)
 	return client.Do(req)
 }


### PR DESCRIPTION
Enable customization of the UA used when fetching URL previews.

This is useful, for example, to fix Twitter OG previews by including `Bot` somewhere in the UA string.