### PR TITLE
Add users' usage statistics (admin) API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Added support for `image/jxl` thumbnailing.
 * Built-in early support for content ranges (being able to skip around in audio and video). This is only available if
   caching is enabled.
+* Admin endpoint to GET users' usage statistics for a server.
 
 ### Removed
 

--- a/api/auth.go
+++ b/api/auth.go
@@ -113,3 +113,15 @@ func RepoAdminRoute(next func(r *http.Request, rctx rcontext.RequestContext, use
 		return regularFunc(r, rctx)
 	}
 }
+
+func GetRequestUserAdminStatus(r *http.Request, rctx rcontext.RequestContext, user UserInfo) (bool, bool) {
+	isGlobalAdmin := util.IsGlobalAdmin(user.UserId) || user.IsShared
+	isLocalAdmin, err := matrix.IsUserAdmin(rctx, r.Host, user.AccessToken, r.RemoteAddr)
+	if err != nil {
+		sentry.CaptureException(err)
+		rctx.Log.Error("Error verifying local admin: " + err.Error())
+		return isGlobalAdmin, false
+	}
+
+	return isGlobalAdmin, isLocalAdmin
+}

--- a/api/custom/usage.go
+++ b/api/custom/usage.go
@@ -215,12 +215,17 @@ func GetUploadsUsage(r *http.Request, rctx rcontext.RequestContext, user api.Use
 
 // GetUsersUsageStats attempts to provide a loose equivalent to this Synapse admin end-point:
 // https://matrix-org.github.io/synapse/develop/admin_api/statistics.html#users-media-usage-statistics
-func GetUsersUsageStats(r *http.Request, rctx rcontext.RequestContext, _ api.UserInfo) interface{} {
+func GetUsersUsageStats(r *http.Request, rctx rcontext.RequestContext, user api.UserInfo) interface{} {
 	params := mux.Vars(r)
 	qs := r.URL.Query()
 	var err error
 
 	serverName := params["serverName"]
+
+	isGlobalAdmin, isLocalAdmin := api.GetRequestUserAdminStatus(r, rctx, user)
+	if !isGlobalAdmin && (!util.IsServerOurs(serverName) || !isLocalAdmin) {
+		return api.AuthFailed()
+	}
 
 	orderBy := qs.Get("order_by")
 	if len(qs["order_by"]) == 0 {

--- a/api/custom/usage.go
+++ b/api/custom/usage.go
@@ -1,14 +1,19 @@
 package custom
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/getsentry/sentry-go"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 	"github.com/turt2live/matrix-media-repo/api"
 	"github.com/turt2live/matrix-media-repo/common/rcontext"
 	"github.com/turt2live/matrix-media-repo/storage"
+	"github.com/turt2live/matrix-media-repo/storage/stores"
 	"github.com/turt2live/matrix-media-repo/types"
 	"github.com/turt2live/matrix-media-repo/util"
 )
@@ -206,4 +211,127 @@ func GetUploadsUsage(r *http.Request, rctx rcontext.RequestContext, user api.Use
 	}
 
 	return &api.DoNotCacheResponse{Payload: parsed}
+}
+
+// GetUsersUsageStats attempts to provide a loose equivalent to this Synapse admin end-point:
+// https://matrix-org.github.io/synapse/develop/admin_api/statistics.html#users-media-usage-statistics
+func GetUsersUsageStats(r *http.Request, rctx rcontext.RequestContext, _ api.UserInfo) interface{} {
+	params := mux.Vars(r)
+	qs := r.URL.Query()
+	var err error
+
+	serverName := params["serverName"]
+
+	orderBy := qs.Get("order_by")
+	if len(qs["order_by"]) == 0 {
+		orderBy = "user_id"
+	}
+	if !util.ArrayContains(stores.UsersUsageStatsSorts, orderBy) {
+		acceptedValsStr, _ := json.Marshal(stores.UsersUsageStatsSorts)
+		acceptedValsStr = []byte(strings.ReplaceAll(string(acceptedValsStr), "\"", "'"))
+		return api.BadRequest(
+			fmt.Sprintf("Query parameter 'order_by' must be one of %s", acceptedValsStr))
+	}
+
+	var start int64 = 0
+	if len(qs["from"]) > 0 {
+		start, err = strconv.ParseInt(qs.Get("from"), 10, 64)
+		if err != nil || start < 0 {
+			return api.BadRequest("Query parameter 'from' must be a non-negative integer")
+		}
+	}
+
+	var limit int64 = 100
+	if len(qs["limit"]) > 0 {
+		limit, err = strconv.ParseInt(qs.Get("limit"), 10, 64)
+		if err != nil || limit < 0 {
+			return api.BadRequest("Query parameter 'limit' must be a non-negative integer")
+		}
+	}
+
+	const unspecifiedTS int64 = -1
+	fromTS := unspecifiedTS
+	if len(qs["from_ts"]) > 0 {
+		fromTS, err = strconv.ParseInt(qs.Get("from_ts"), 10, 64)
+		if err != nil || fromTS < 0 {
+			return api.BadRequest("Query parameter 'from_ts' must be a non-negative integer")
+		}
+	}
+
+	untilTS := unspecifiedTS
+	if len(qs["until_ts"]) > 0 {
+		untilTS, err = strconv.ParseInt(qs.Get("until_ts"), 10, 64)
+		if err != nil || untilTS < 0 {
+			return api.BadRequest("Query parameter 'until_ts' must be a non-negative integer")
+		} else if untilTS <= fromTS {
+			return api.BadRequest("Query parameter 'until_ts' must be greater than 'from_ts'")
+		}
+	}
+
+	searchTerm := qs.Get("search_term")
+	if searchTerm == "" && len(qs["search_term"]) > 0 {
+		return api.BadRequest("Query parameter 'search_term' cannot be an empty string")
+	}
+
+	isAscendingOrder := true
+	direction := qs.Get("dir")
+	if direction == "f" || len(qs["dir"]) == 0 {
+		// Use default order
+	} else if direction == "b" {
+		isAscendingOrder = false
+	} else {
+		return api.BadRequest("Query parameter 'dir' must be one of ['f', 'b']")
+	}
+
+	rctx = rctx.LogWithFields(logrus.Fields{
+		"serverName":       serverName,
+		"order_by":         orderBy,
+		"from":             start,
+		"limit":            limit,
+		"from_ts":          fromTS,
+		"until_ts":         untilTS,
+		"search_term":      searchTerm,
+		"isAscendingOrder": isAscendingOrder,
+	})
+
+	db := storage.GetDatabase().GetMediaStore(rctx)
+
+	stats, totalCount, err := db.GetUsersUsageStatsForServer(
+		serverName,
+		orderBy,
+		start,
+		limit,
+		fromTS,
+		untilTS,
+		searchTerm,
+		isAscendingOrder)
+
+	if err != nil {
+		rctx.Log.Error(err)
+		sentry.CaptureException(err)
+		return api.InternalServerError("Failed to get users' usage stats on specified server")
+	}
+
+	var users []map[string]interface{}
+	if len(stats) == 0 {
+		users = []map[string]interface{}{}
+	} else {
+		for _, record := range stats {
+			users = append(users, map[string]interface{}{
+				"media_count":  record.MediaCount,
+				"media_length": record.MediaLength,
+				"user_id":      record.UserId,
+			})
+		}
+	}
+
+	var result = map[string]interface{}{
+		"users": users,
+		"total": totalCount,
+	}
+	if (start + limit) < totalCount {
+		result["next_token"] = start + int64(len(stats))
+	}
+
+	return &api.DoNotCacheResponse{Payload: result}
 }

--- a/api/webserver/webserver.go
+++ b/api/webserver/webserver.go
@@ -71,6 +71,7 @@ func Init() *sync.WaitGroup {
 	domainUsageHandler := handler{api.RepoAdminRoute(custom.GetDomainUsage), "domain_usage", counter, false}
 	userUsageHandler := handler{api.RepoAdminRoute(custom.GetUserUsage), "user_usage", counter, false}
 	uploadsUsageHandler := handler{api.RepoAdminRoute(custom.GetUploadsUsage), "uploads_usage", counter, false}
+	usersUsageStatsHandler := handler{api.RepoAdminRoute(custom.GetUsersUsageStats), "users_usage_stats", counter, false}
 	getBackgroundTaskHandler := handler{api.RepoAdminRoute(custom.GetTask), "get_background_task", counter, false}
 	listAllBackgroundTasksHandler := handler{api.RepoAdminRoute(custom.ListAllTasks), "list_all_background_tasks", counter, false}
 	listUnfinishedBackgroundTasksHandler := handler{api.RepoAdminRoute(custom.ListUnfinishedTasks), "list_unfinished_background_tasks", counter, false}
@@ -131,6 +132,7 @@ func Init() *sync.WaitGroup {
 		routes = append(routes, definedRoute{"/_matrix/media/" + version + "/admin/federation/test/{serverName:[a-zA-Z0-9.:\\-_]+}", route{"GET", fedTestHandler}})
 		routes = append(routes, definedRoute{"/_matrix/media/" + version + "/admin/usage/{serverName:[a-zA-Z0-9.:\\-_]+}", route{"GET", domainUsageHandler}})
 		routes = append(routes, definedRoute{"/_matrix/media/" + version + "/admin/usage/{serverName:[a-zA-Z0-9.:\\-_]+}/users", route{"GET", userUsageHandler}})
+		routes = append(routes, definedRoute{"/_matrix/media/" + version + "/admin/usage/{serverName:[a-zA-Z0-9.:\\-_]+}/users-stats", route{"GET", usersUsageStatsHandler}})
 		routes = append(routes, definedRoute{"/_matrix/media/" + version + "/admin/usage/{serverName:[a-zA-Z0-9.:\\-_]+}/uploads", route{"GET", uploadsUsageHandler}})
 		routes = append(routes, definedRoute{"/_matrix/media/" + version + "/admin/tasks/{taskId:[0-9]+}", route{"GET", getBackgroundTaskHandler}})
 		routes = append(routes, definedRoute{"/_matrix/media/" + version + "/admin/tasks/all", route{"GET", listAllBackgroundTasksHandler}})

--- a/api/webserver/webserver.go
+++ b/api/webserver/webserver.go
@@ -71,7 +71,7 @@ func Init() *sync.WaitGroup {
 	domainUsageHandler := handler{api.RepoAdminRoute(custom.GetDomainUsage), "domain_usage", counter, false}
 	userUsageHandler := handler{api.RepoAdminRoute(custom.GetUserUsage), "user_usage", counter, false}
 	uploadsUsageHandler := handler{api.RepoAdminRoute(custom.GetUploadsUsage), "uploads_usage", counter, false}
-	usersUsageStatsHandler := handler{api.RepoAdminRoute(custom.GetUsersUsageStats), "users_usage_stats", counter, false}
+	usersUsageStatsHandler := handler{api.AccessTokenRequiredRoute(custom.GetUsersUsageStats), "users_usage_stats", counter, false}
 	getBackgroundTaskHandler := handler{api.RepoAdminRoute(custom.GetTask), "get_background_task", counter, false}
 	listAllBackgroundTasksHandler := handler{api.RepoAdminRoute(custom.ListAllTasks), "list_all_background_tasks", counter, false}
 	listUnfinishedBackgroundTasksHandler := handler{api.RepoAdminRoute(custom.ListUnfinishedTasks), "list_unfinished_background_tasks", counter, false}

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -230,6 +230,38 @@ The response is how much data the server is using:
 
 Use the same endpoint as above, but specifying one or more `?user_id=@alice:example.org` query parameters. Note that encoding the values may be required (not shown here). Users that are unknown to the media repo will not be returned.
 
+#### All known users' usage statistics
+
+Similar to [Per-user usage (all known users)](#per-user-usage-all-known-users), but with a focus on statistics, and with
+parameterized querying ability.
+
+This end-point attempts to be a loose equivalent to
+[this](https://matrix-org.github.io/synapse/develop/admin_api/statistics.html#users-media-usage-statistics) Synapse
+endpoint, with the main difference being the absence of "displayname".
+
+URL: `GET /_matrix/media/unstable/admin/usage/<server name>/users-stats?access_token=your_access_token`
+
+Example response:
+```json
+{
+  "next_token" : 100,
+  "total" : 105,
+  "users" : [
+    {
+      "media_count" : 12,
+      "media_length" : 39546,
+      "user_id" : "@alice:example.com"
+    },
+    {
+      "media_count" : 46,
+      "media_length" : 5935234,
+      "user_id" : "@bob:example.com"
+    },
+    ...
+  ]
+}
+```
+
 #### Per-upload usage (all uploads)
 
 URL: `GET /_matrix/media/unstable/admin/usage/<server name>/uploads?access_token=your_access_token`

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -171,7 +171,7 @@ The `task_id` can be given to the Background Tasks API described below.
 
 ## Data usage for servers/users
 
-Individual servers and users can often hoard data in the media repository. These endpoints will tell you how much. These endpoints can only be called by repository admins - they are not available to admins of the homeservers.
+Individual servers and users can often hoard data in the media repository. These endpoints will tell you how much. Unless stated otherwise (below), these endpoints can only be called by repository admins - they are not available to admins of the homeservers.
 
 **Caution**: These endpoints may return *lots* of data. Making very specific requests is recommended.
 
@@ -232,8 +232,11 @@ Use the same endpoint as above, but specifying one or more `?user_id=@alice:exam
 
 #### All known users' usage statistics
 
-Similar to [Per-user usage (all known users)](#per-user-usage-all-known-users), but with a focus on statistics, and with
-parameterized querying ability.
+Similar to [Per-user usage (all known users)](#per-user-usage-all-known-users), but with:
+
+* a focus on statistics
+* parameterized querying ability
+* relaxed authorization restrictions (to allow homeserver admins to query against their own homeserver)
 
 This end-point attempts to be a loose equivalent to
 [this](https://matrix-org.github.io/synapse/develop/admin_api/statistics.html#users-media-usage-statistics) Synapse

--- a/storage/stores/media_store.go
+++ b/storage/stores/media_store.go
@@ -537,7 +537,10 @@ func (s *MediaStore) GetUsersUsageStatsForServer(
 		orderDirection,
 		limitClause,
 		offsetClause)
-	rows, err := s.factory.sqlDb.Query(paginationQuery, append(commonQueryParams, otherPaginationParams...)...)
+	rows, err := s.factory.sqlDb.QueryContext(
+		s.ctx,
+		paginationQuery,
+		append(commonQueryParams, otherPaginationParams...)...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -564,7 +567,7 @@ func (s *MediaStore) GetUsersUsageStatsForServer(
 			") as count_user_ids; ",
 		commonQueryPortion)
 	var totalNumRows int64 = 0
-	err = s.factory.sqlDb.QueryRow(totalQuery, commonQueryParams...).Scan(&totalNumRows)
+	err = s.factory.sqlDb.QueryRowContext(s.ctx, totalQuery, commonQueryParams...).Scan(&totalNumRows)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/types/media.go
+++ b/types/media.go
@@ -35,6 +35,12 @@ type MinimalMediaMetadata struct {
 	DatastoreId  string
 }
 
+type UserUsageStats struct {
+	MediaCount  int64
+	MediaLength int64
+	UserId      string
+}
+
 func (m *Media) MxcUri() string {
 	return "mxc://" + m.Origin + "/" + m.MediaId
 }


### PR DESCRIPTION
# Purpose

Provide a loose equivalent to the following Synapse admin end-point:
https://matrix-org.github.io/synapse/develop/admin_api/statistics.html#users-media-usage-statistics

# Miscellaneous

This is my first time writing Golang, so please bear that in mind if/when you shake your head/fist at the potential lack of Golang idioms :smile: . Having said that, I'm very open to constructive criticism.