### PR TITLE
Allow configuring per-user limits on upload size.

### DIFF
--- a/api/r0/public_config.go
+++ b/api/r0/public_config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/turt2live/matrix-media-repo/api"
 	"github.com/turt2live/matrix-media-repo/common/rcontext"
+	"github.com/turt2live/matrix-media-repo/quota"
 )
 
 type PublicConfigResponse struct {
@@ -12,15 +13,7 @@ type PublicConfigResponse struct {
 }
 
 func PublicConfig(r *http.Request, rctx rcontext.RequestContext, user api.UserInfo) interface{} {
-	uploadSize := rctx.Config.Uploads.ReportedMaxSizeBytes
-	if uploadSize == 0 {
-		uploadSize = rctx.Config.Uploads.MaxSizeBytes
-	}
-
-	if uploadSize < 0 {
-		uploadSize = 0 // invokes the omitEmpty
-	}
-
+	uploadSize := quota.GetUserUploadMaxSizeBytes(rctx, user.UserId)
 	return &PublicConfigResponse{
 		UploadMaxSize: uploadSize,
 	}

--- a/api/r0/upload.go
+++ b/api/r0/upload.go
@@ -1,11 +1,12 @@
 package r0
 
 import (
-	"github.com/getsentry/sentry-go"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
+
+	"github.com/getsentry/sentry-go"
 
 	"github.com/sirupsen/logrus"
 	"github.com/turt2live/matrix-media-repo/api"
@@ -35,7 +36,7 @@ func UploadMedia(r *http.Request, rctx rcontext.RequestContext, user api.UserInf
 		contentType = "application/octet-stream" // binary
 	}
 
-	if upload_controller.IsRequestTooLarge(r.ContentLength, r.Header.Get("Content-Length"), rctx) {
+	if upload_controller.IsRequestTooLarge(r.ContentLength, r.Header.Get("Content-Length"), rctx, user.UserId) {
 		io.Copy(ioutil.Discard, r.Body) // Ditch the entire request
 		return api.RequestTooLarge()
 	}

--- a/common/config/models_domain.go
+++ b/common/config/models_domain.go
@@ -17,10 +17,11 @@ type QuotasConfig struct {
 }
 
 type UploadsConfig struct {
-	MaxSizeBytes         int64        `yaml:"maxBytes"`
-	MinSizeBytes         int64        `yaml:"minBytes"`
-	ReportedMaxSizeBytes int64        `yaml:"reportedMaxBytes"`
-	Quota                QuotasConfig `yaml:"quotas"`
+	MaxSizeBytes         int64             `yaml:"maxBytes"`
+	UsersMaxSizeBytes    []QuotaUserConfig `yaml:"quotas,flow"`
+	MinSizeBytes         int64             `yaml:"minBytes"`
+	ReportedMaxSizeBytes int64             `yaml:"reportedMaxBytes"`
+	Quota                QuotasConfig      `yaml:"quotas"`
 }
 
 type DatastoreConfig struct {

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -214,6 +214,10 @@ uploads:
   # The maximum individual file size a user can upload.
   maxBytes: 104857600 # 100MB default, 0 to disable
 
+  usersMaxBytes: 
+    - glob: "@*:*"  # Affect all users. Use asterisks (*) to match any character.
+      maxBytes: 104857600 # 100MB default, 0 to disable
+  
   # The minimum number of bytes to let people upload. This is recommended to be non-zero to
   # ensure that the "cost" of running the media repo is worthwhile - small file uploads tend
   # to waste more CPU and database resources than small files, thus a default of 100 bytes

--- a/controllers/preview_controller/preview_resource_handler.go
+++ b/controllers/preview_controller/preview_resource_handler.go
@@ -2,8 +2,9 @@ package preview_controller
 
 import (
 	"fmt"
-	"github.com/getsentry/sentry-go"
 	"sync"
+
+	"github.com/getsentry/sentry-go"
 
 	"github.com/disintegration/imaging"
 	"github.com/sirupsen/logrus"
@@ -129,7 +130,7 @@ func urlPreviewWorkFn(request *resource_handler.WorkRequest) (resp *urlPreviewRe
 	}
 
 	// Store the thumbnail, if there is one
-	if preview.Image != nil && !upload_controller.IsRequestTooLarge(preview.Image.ContentLength, preview.Image.ContentLengthHeader, ctx) {
+	if preview.Image != nil && !upload_controller.IsRequestTooLarge(preview.Image.ContentLength, preview.Image.ContentLengthHeader, ctx, info.forUserId) {
 		contentLength := upload_controller.EstimateContentLength(preview.Image.ContentLength, preview.Image.ContentLengthHeader)
 
 		// UploadMedia will close the read stream for the thumbnail and dedupe the image

--- a/quota/quota.go
+++ b/quota/quota.go
@@ -33,3 +33,19 @@ func IsUserWithinQuota(ctx rcontext.RequestContext, userId string) (bool, error)
 
 	return true, nil // no rules == no quota
 }
+
+func GetUserUploadMaxSizeBytes(ctx rcontext.RequestContext, userId string) int64 {
+	var maxValue int64 = 0
+	for _, q := range ctx.Config.Uploads.UsersMaxSizeBytes {
+		if glob.Glob(q.Glob, userId) {
+			if q.MaxBytes > maxValue {
+				maxValue = q.MaxBytes
+			}
+		}
+	}
+	if maxValue == 0 {
+		return ctx.Config.Uploads.MaxSizeBytes
+	} else {
+		return maxValue
+	}
+}


### PR DESCRIPTION
I believe [the spec](https://spec.matrix.org/v1.1/client-server-api/#get_matrixmediav3config) allows for this by making this endpoint authenticated. The need for this feature is to support lowering the media uploads allowed by bridge users while retaining a higher limit for native Matrix users.