### PR TITLE
Fix arm64 system build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM golang:1.18-alpine AS builder
 
 # Install build dependencies
-RUN apk add --no-cache git musl-dev dos2unix build-base
+RUN apk add --no-cache git musl-dev dos2unix build-base binutils-gold
 
 WORKDIR /opt
 COPY . /opt


### PR DESCRIPTION
Alpine system needs to install binutils-gold dependency

<img width="669" alt="WindowsTerminal_QLDpXebNlX" src="https://user-images.githubusercontent.com/56180468/213879570-cca207e6-ed4b-4d7a-9da9-659aecea019a.png">
