### PR TITLE
Reduce info logging noise

### DIFF
--- a/api/_auth_cache/auth_cache.go
+++ b/api/_auth_cache/auth_cache.go
@@ -94,7 +94,7 @@ func GetUserId(ctx rcontext.RequestContext, accessToken string, appserviceUserId
 		if token.err != nil {
 			return "", token.err
 		}
-		ctx.Log.Infof("Access token belongs to %s", token.userId)
+		ctx.Log.Debugf("Access token belongs to %s", token.userId)
 		return token.userId, nil
 	}
 
@@ -109,7 +109,7 @@ func GetUserId(ctx rcontext.RequestContext, accessToken string, appserviceUserId
 		}
 
 		if r.SenderUserId != "" && (r.SenderUserId == appserviceUserId || appserviceUserId == "") {
-			ctx.Log.Infof("Access token belongs to appservice (sender user ID): %s", r.Id)
+			ctx.Log.Debugf("Access token belongs to appservice (sender user ID): %s", r.Id)
 			cacheToken(ctx, accessToken, appserviceUserId, r.SenderUserId, nil)
 			return r.SenderUserId, nil
 		}
@@ -121,7 +121,7 @@ func GetUserId(ctx rcontext.RequestContext, accessToken string, appserviceUserId
 				regexCache[n.Regex] = regex
 			}
 			if regex.MatchString(appserviceUserId) {
-				ctx.Log.Infof("Access token belongs to appservice: %s", r.Id)
+				ctx.Log.Debugf("Access token belongs to appservice: %s", r.Id)
 				cacheToken(ctx, accessToken, appserviceUserId, appserviceUserId, nil)
 				return appserviceUserId, nil
 			}
@@ -144,10 +144,10 @@ func cacheToken(ctx rcontext.RequestContext, accessToken string, appserviceUserI
 }
 
 func checkTokenWithHomeserver(ctx rcontext.RequestContext, accessToken string, appserviceUserId string, withCache bool) (string, error) {
-	ctx.Log.Info("Checking access token with homeserver")
+	ctx.Log.Debug("Checking access token with homeserver")
 	hsUserId, err := matrix.GetUserIdFromToken(ctx, ctx.Request.Host, accessToken, appserviceUserId, ctx.Request.RemoteAddr)
 	if withCache {
-		ctx.Log.Info("Caching access token response from homeserver")
+		ctx.Log.Debug("Caching access token response from homeserver")
 		cacheToken(ctx, accessToken, appserviceUserId, hsUserId, err)
 	}
 	return hsUserId, err

--- a/api/_routers/98-use-rcontext.go
+++ b/api/_routers/98-use-rcontext.go
@@ -63,7 +63,7 @@ func (c *RContextRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Check for HTML response and reply accordingly
 	if htmlRes, isHtml := res.(*_responses.HtmlResponse); isHtml {
-		log.Infof("Replying with result: %T <%d chars of html>", res, len(htmlRes.HTML))
+		log.Debugf("Replying with result: %T <%d chars of html>", res, len(htmlRes.HTML))
 
 		// Write out HTML here, now that we know it's happening
 		if shouldCache {
@@ -88,7 +88,7 @@ func (c *RContextRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	expectedBytes := int64(0)
 	var contentType string
 beforeParseDownload:
-	log.Infof("Replying with result: %T %+v", res, res)
+	log.Debugf("Replying with result: %T %+v", res, res)
 	if downloadRes, isDownload := res.(*_responses.DownloadResponse); isDownload {
 		doRange, rangeStart, rangeEnd, grabBytes, rangeErrMsg := parseRange(r, downloadRes)
 		if doRange && rangeErrMsg != "" {

--- a/controllers/download_controller/download_controller.go
+++ b/controllers/download_controller/download_controller.go
@@ -167,7 +167,7 @@ func FindMinimalMediaRecord(origin string, mediaId string, downloadRemote bool, 
 	if found {
 		media = item.(*types.Media)
 	} else {
-		ctx.Log.Info("Getting media record from database")
+		ctx.Log.Debug("Getting minimal media record from database")
 		dbMedia, err := db.Get(origin, mediaId)
 		if err != nil {
 			if err == sql.ErrNoRows {
@@ -262,7 +262,7 @@ func FindMediaRecord(origin string, mediaId string, downloadRemote bool, ctx rco
 		if found {
 			media = item.(*types.Media)
 		} else {
-			ctx.Log.Info("Getting media record from database")
+			ctx.Log.Debug("Getting media record from database")
 			dbMedia, err := db.Get(origin, mediaId)
 			if err != nil {
 				if err == sql.ErrNoRows {


### PR DESCRIPTION
Both of these are cropping up for every media request and making the logs balloon in size for a fairly active deployment. In both cases I think these would be better served as debug flags during actual investigation.