### PR TITLE
disable using the x-amz-checksum header

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -191,6 +191,10 @@ datastores:
       # An optional storage class for tuning how the media is stored at s3.
       # See https://aws.amazon.com/s3/storage-classes/ for details; uncomment to use.
       #storageClass: STANDARD
+      # If you're seeing errors relating to 'z-amz-checksum-algorithm CRC32C not implemented',
+      # set this to `true`. This will reduce performance, but will allow uploads to be possible.
+      # It is common that you need to enable this with Backblaze B2 and CloudFlare R2.
+      useMD5: false
 
 # Options for controlling archives. Archives are exports of a particular user's content for
 # the purpose of GDPR or moving media to a different server.

--- a/datastores/s3.go
+++ b/datastores/s3.go
@@ -15,6 +15,7 @@ type s3 struct {
 	client       *minio.Client
 	storageClass string
 	bucket       string
+	putWithMd5   bool
 }
 
 func getS3(ds config.DatastoreConfig) (*s3, error) {
@@ -29,6 +30,7 @@ func getS3(ds config.DatastoreConfig) (*s3, error) {
 	region := ds.Options["region"]
 	storageClass, hasStorageClass := ds.Options["storageClass"]
 	useSslStr, hasSsl := ds.Options["ssl"]
+	useMd5Str, hasMd5 := ds.Options["useMD5"]
 
 	if !hasStorageClass {
 		storageClass = "STANDARD"
@@ -37,6 +39,11 @@ func getS3(ds config.DatastoreConfig) (*s3, error) {
 	useSsl := true
 	if hasSsl && useSslStr != "" {
 		useSsl, _ = strconv.ParseBool(useSslStr)
+	}
+
+	useMd5 := false
+	if hasMd5 && useMd5Str != "" {
+		useMd5, _ = strconv.ParseBool(useMd5Str)
 	}
 
 	var err error
@@ -54,6 +61,7 @@ func getS3(ds config.DatastoreConfig) (*s3, error) {
 		client:       client,
 		storageClass: storageClass,
 		bucket:       bucket,
+		putWithMd5:   useMd5,
 	}
 	s3clients.Store(ds.Id, s3c)
 	return s3c, nil

--- a/datastores/upload.go
+++ b/datastores/upload.go
@@ -61,7 +61,11 @@ func Upload(ctx rcontext.RequestContext, ds config.DatastoreConfig, data io.Read
 
 		metrics.S3Operations.With(prometheus.Labels{"operation": "PutObject"}).Inc()
 		var info minio.UploadInfo
-		info, err = s3c.client.PutObject(ctx.Context, s3c.bucket, objectName, tee, size, minio.PutObjectOptions{StorageClass: s3c.storageClass, ContentType: contentType})
+		info, err = s3c.client.PutObject(ctx.Context, s3c.bucket, objectName, tee, size, minio.PutObjectOptions{
+			StorageClass:   s3c.storageClass,
+			ContentType:    contentType,
+			SendContentMd5: s3c.putWithMd5,
+		})
 		uploadedBytes = info.Size
 	} else if ds.Type == "file" {
 		basePath := ds.Options["path"]

--- a/storage/datastore/ds_s3/s3_store.go
+++ b/storage/datastore/ds_s3/s3_store.go
@@ -186,7 +186,7 @@ func (s *s3Datastore) UploadFile(file io.ReadCloser, expectedLength int64, ctx r
 		}
 		ctx.Log.Info("Uploading file...")
 		metrics.S3Operations.With(prometheus.Labels{"operation": "PutObject"}).Inc()
-		sizeBytes, uploadErr = s.client.PutObjectWithContext(ctx, s.bucket, objectName, rs3, expectedLength, minio.PutObjectOptions{StorageClass: s.storageClass})
+		sizeBytes, uploadErr = s.client.PutObjectWithContext(ctx, s.bucket, objectName, rs3, expectedLength, minio.PutObjectOptions{StorageClass: s.storageClass, SendContentMd5: true})
 		ctx.Log.Info("Uploaded ", sizeBytes, " bytes to s3")
 		done <- true
 	}()
@@ -237,7 +237,7 @@ func (s *s3Datastore) ObjectExists(location string) bool {
 func (s *s3Datastore) OverwriteObject(location string, stream io.ReadCloser) error {
 	defer stream_util.DumpAndCloseStream(stream)
 	metrics.S3Operations.With(prometheus.Labels{"operation": "PutObject"}).Inc()
-	_, err := s.client.PutObject(s.bucket, location, stream, -1, minio.PutObjectOptions{StorageClass: s.storageClass})
+	_, err := s.client.PutObject(s.bucket, location, stream, -1, minio.PutObjectOptions{StorageClass: s.storageClass, SendContentMd5: true})
 	return err
 }
 


### PR DESCRIPTION
Not all S3 implementations support it. Support for providers intentionally broken by minio, see: https://github.com/minio/minio-go/issues/1791

This *could* be a minor performance regression in the case that the connection to your S3-compatible storage provider is faster than the speed at which either side can hash the data using MD5. This restores Backblaze B2 and Cloudflare R2 support.