### PR TITLE
Make sure the buffer temp path is writable

### DIFF
--- a/datastores/buffer.go
+++ b/datastores/buffer.go
@@ -32,7 +32,7 @@ func BufferTemp(datastore config.DatastoreConfig, contents io.ReadCloser) (strin
 		logrus.Warnf("Datastore %s does not have a valid temporary path configured. This will lead to increased memory usage.", datastore.Id)
 		target = &bytes.Buffer{}
 	} else {
-		err = os.Mkdir(fpath, os.ModeDir)
+		err = os.Mkdir(fpath, os.ModeDir | 0700)
 		if err != nil && !os.IsExist(err) {
 			return "", 0, nil, errors.New("error creating temp path: " + err.Error())
 		}


### PR DESCRIPTION
When creating a temp dir for buffering files before uploading to S3 in [buffer.go](https://github.com/turt2live/matrix-media-repo/blob/209d91b10e9395dd6b8f628a477beb71091ecde5/datastores/buffer.go#L35), the directory is created without any permissions, so file uploads fail.

Relevant configuration:
```yaml
datastores:
- type: s3
  id: ...
  forKinds: ["all"]
  opts:
    endpoint: s3.eu-central-003.backblazeb2.com
    ssl: true
    bucketName: ...
    accessKeyId: ...
    accessSecret: ...
    tempPath: /tmp/s3-upload/
```
The directory `/tmp/s3-upload/` already exists before starting `matrix-media-repo` with the correct owner and permissions `700`. As soon as a single file is uploaded, the directory is recreated with permissions `000`, so `matrix-media-repo` can't create any files inside the directory. All uploads fail with `error generating temporary file: open /tmp/s3-upload/mmr...: permission denied`. With this patch applied, uploading files works again.