### PR TITLE
Remove double `https:` from export URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Dendrite homeservers can now have their media imported safely, and `adminApiKind` may be set to `dendrite`.
 
+### Fixed
+
+* Exports created with `s3_urls` now contain valid URLs.
+
 ## [1.3.3] - October 31, 2023
 
 ### Fixed

--- a/datastores/s3.go
+++ b/datastores/s3.go
@@ -91,7 +91,7 @@ func GetS3Url(ds config.DatastoreConfig, location string) (string, error) {
 	}
 
 	// HACK: Surely there's a better way...
-	return fmt.Sprintf("https://%s/%s/%s", s3c.client.EndpointURL(), s3c.bucket, location), nil
+	return fmt.Sprintf("%s/%s/%s", s3c.client.EndpointURL(), s3c.bucket, location), nil
 }
 
 func ParseS3Url(s3url string) (config.DatastoreConfig, string, error) {


### PR DESCRIPTION
Fixes https://github.com/turt2live/matrix-media-repo/issues/505