### PR TITLE
Fix docs export delete endpoint

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -464,7 +464,7 @@ Then one can call the following to download each part:
 
 After the export has been downloaded, it can be deleted. Note that this endpoint can be called by the user from the "view export" page.
 
-`DELETE /_matrix/media/unstable/admin/export/<export ID>`
+`DELETE /_matrix/media/unstable/admin/export/<export ID>/delete`
 
 The response is an empty JSON object if successful.
 


### PR DESCRIPTION
The current documented endpoint just returns a 404. The code says it requires a `/delete` suffix.

https://github.com/turt2live/matrix-media-repo/blob/v1.3.3/api/routes.go#L105