### PR TITLE
gracefully handle empty uploader user ids during archive import

### DIFF
--- a/archival/v2archive/reader.go
+++ b/archival/v2archive/reader.go
@@ -241,15 +241,17 @@ func (r *ArchiveReader) importFileFromStream(fileName string, f io.ReadCloser, o
 
 		serverName := r.manifest.EntityId
 		userId := metadata.Uploader
-		if userId[0] != '@' {
-			userId = ""
-		} else {
-			_, s, err := util.SplitUserId(userId)
-			if err != nil {
-				r.ctx.Log.Warnf("Invalid user ID: %s (media %s)", userId, mxc)
-				serverName = ""
+		if userId != "" {
+			if userId[0] != '@' {
+				userId = ""
 			} else {
-				serverName = s
+				_, s, err := util.SplitUserId(userId)
+				if err != nil {
+					r.ctx.Log.Warnf("Invalid user ID: %s (media %s)", userId, mxc)
+					serverName = ""
+				} else {
+					serverName = s
+				}
 			}
 		}
 		kind := datastores.LocalMediaKind


### PR DESCRIPTION
trying to import a previously exported archive throws an out of range panic with the following stack trace:

```
panic: runtime error: index out of range [0] with length 0

goroutine 124 [running]:
github.com/turt2live/matrix-media-repo/archival/v2archive.(*ArchiveReader).importFileFromStream(0x40001c4000, {0x400034a910, 0x47}, {0x1262ad8, 0x400035a2a0}, {{0x0?, 0x40004cfc48?}, 0x60?})
        /opt/archival/v2archive/reader.go:244 +0x8cc
github.com/turt2live/matrix-media-repo/archival/v2archive.(*ArchiveReader).ProcessFile.func1(0x400017e700, {0x125a760, 0x40004406c0})
        /opt/archival/v2archive/reader.go:181 +0x13c
github.com/turt2live/matrix-media-repo/archival/v2archive.readArchive({0x1261ed0?, 0x4000522110}, 0x40004cfd78)
        /opt/archival/v2archive/reader.go:67 +0x1dc
github.com/turt2live/matrix-media-repo/archival/v2archive.(*ArchiveReader).ProcessFile(0x40004cff38?, {0x1261ed0?, 0x4000522110?}, {{0x0?, 0xed73a0?}, 0x0?})
        /opt/archival/v2archive/reader.go:179 +0xa4
github.com/turt2live/matrix-media-repo/tasks/task_runner.(*importEngine).workFn(0x4000498dc0, 0x40005b6420)
        /opt/tasks/task_runner/import_data.go:137 +0x110
created by github.com/turt2live/matrix-media-repo/tasks/task_runner.createEngine
        /opt/tasks/task_runner/import_data.go:59 +0x318
```

this patch fixes the out of range error by skipping the entire logic of parsing the user id if its empty